### PR TITLE
fix: blank e-ink panel when display sleeps

### DIFF
--- a/vendor/MP01_services/MP01_accessibility_service/src/com/lmqr/MP01_comp_service/MP01AccessibilityService.kt
+++ b/vendor/MP01_services/MP01_accessibility_service/src/com/lmqr/MP01_comp_service/MP01AccessibilityService.kt
@@ -60,6 +60,7 @@ class MP01AccessibilityService : AccessibilityService(),
                             commandRunner.runCommands(arrayOf(Commands.SPEED_CLEAR))
                         }, 50)
                     brightnessManager.turnOffBrightness()
+                    commandRunner.runCommands(arrayOf(Commands.FORCE_CLEAR, Commands.COMMIT_BITMAP))
                 }
                 Intent.ACTION_SCREEN_ON -> {
                     isScreenOn = true


### PR DESCRIPTION
When the screen turns off, the frontlights (cold/warm/keyboard) were turned off but the e-ink panel itself retained the last displayed image. E-ink is bistable — it holds the image without power — so in bright ambient light, the screen content remained visible even while 'asleep,' and partial refreshes during the power transition sometimes caused ghosting/inversion.

**Fix:** Run `FORCE_CLEAR` (`"r"` → writes "5" to `eink_cpld_registers`) followed by `COMMIT_BITMAP` (`"cm"` → writes "1" to `epd_commit_bitmap`) via the e-ink daemon Unix socket after turning off the backlights on `ACTION_SCREEN_OFF`.

These commands already exist in the e-ink daemon (`eink_daemon.c`) and the `Commands.kt` constants — they just weren't being invoked during sleep.

Closes #5